### PR TITLE
Remove words with potential to generate offensive phrases

### DIFF
--- a/lib/CtrlO/Crypt/XkcdPassword/Wordlist/en_gb.pm
+++ b/lib/CtrlO/Crypt/XkcdPassword/Wordlist/en_gb.pm
@@ -95,7 +95,6 @@ abolish
 abolition
 aborigine
 abort
-abortion
 abortive
 abound
 about
@@ -124,8 +123,6 @@ absurdity
 absurdly
 abundance
 abundant
-abuse
-abuser
 abusive
 abysmal
 academic
@@ -617,7 +614,6 @@ ascent
 ascertain
 ascetic
 ascribe
-asexual
 ashcan
 ashen
 ashore
@@ -636,8 +632,6 @@ aspirin
 assail
 assailant
 assassin
-assault
-assaulter
 assemble
 assembler
 assembly
@@ -835,7 +829,6 @@ barbarian
 barbaric
 barbecue
 barber
-bareback
 barefoot
 barely
 barer
@@ -871,7 +864,6 @@ basil
 basin
 basket
 bassoon
-bastard
 baste
 batch
 bathe
@@ -995,14 +987,10 @@ beware
 bewilder
 bewitch
 beyond
-bible
-biblical
 bicker
 bicycle
 bidden
 biennial
-bigamist
-bigamy
 bigger
 bigot
 bigotry
@@ -1029,7 +1017,6 @@ birthmark
 biscuit
 bishop
 bison
-bitch
 bitmap
 bitten
 bitter
@@ -1111,7 +1098,6 @@ blown
 blowout
 blowtorch
 blubber
-bludgeon
 bluebell
 blueberry
 bluebird
@@ -1146,11 +1132,9 @@ bologna
 bolster
 bombard
 bomber
-bondage
 bonfire
 bonier
 bonnet
-booby
 bookcase
 bookend
 booklet
@@ -1175,7 +1159,6 @@ boringly
 borne
 borough
 borrow
-bosom
 bossier
 bossy
 botanical
@@ -1246,7 +1229,6 @@ breakable
 breakdown
 breakfast
 breakneck
-breast
 breath
 breathe
 breather
@@ -1338,7 +1320,6 @@ buffalo
 buffer
 buffet
 buffoon
-bugger
 buggier
 buggy
 bugle
@@ -1359,7 +1340,6 @@ bullfrog
 bullion
 bully
 bumblebee
-bummer
 bumper
 bumpier
 bumpy
@@ -1406,7 +1386,6 @@ butter
 buttercup
 butterfly
 buttery
-buttock
 button
 buxom
 buyer
@@ -1822,7 +1801,6 @@ clearance
 clearer
 clearly
 cleat
-cleavage
 cleave
 cleaver
 cleft
@@ -1901,7 +1879,6 @@ cobble
 cobbler
 cobra
 cobweb
-cocaine
 cockier
 cockpit
 cockroach
@@ -1979,7 +1956,6 @@ commonly
 commotion
 communal
 commune
-communion
 communism
 communist
 community
@@ -2031,7 +2007,6 @@ condemn
 condense
 condiment
 condition
-condom
 condone
 condor
 conducive
@@ -2696,7 +2671,6 @@ deviant
 deviate
 deviation
 device
-devil
 devoid
 devolve
 devote
@@ -3144,7 +3118,6 @@ eighth
 eightieth
 eighty
 either
-ejaculate
 eject
 ejection
 elaborate
@@ -3364,11 +3337,9 @@ erase
 eraser
 erasure
 erect
-erection
 ergonomic
 erode
 erosion
-erotic
 errand
 errant
 erratic
@@ -3562,7 +3533,6 @@ factory
 factual
 factually
 faculty
-faggot
 failure
 faint
 fainter
@@ -3688,8 +3658,6 @@ fickle
 fickler
 fiction
 fictional
-fiddle
-fiddler
 fiddly
 fidelity
 fidget
@@ -3934,12 +3902,10 @@ foreman
 foremen
 foremost
 forensic
-foreplay
 foresaw
 foresee
 foreseen
 foresight
-foreskin
 forestall
 forestry
 foretaste
@@ -4216,8 +4182,6 @@ genial
 genially
 genie
 genii
-genital
-genocide
 genre
 gentile
 gentility
@@ -4263,7 +4227,6 @@ gingerly
 gingham
 giraffe
 girder
-girdle
 girlhood
 girlish
 girth
@@ -4799,7 +4762,6 @@ holler
 hollow
 hollower
 holly
-holocaust
 holster
 homage
 homeland
@@ -5450,10 +5412,7 @@ keyword
 khaki
 kickback
 kickoff
-kidnap
-kidnapper
 kidney
-killer
 kilobyte
 kilogram
 kilometre
@@ -5481,7 +5440,6 @@ knead
 kneecap
 kneel
 knelt
-knife
 knight
 knock
 knocker
@@ -5639,7 +5597,6 @@ leopard
 leotard
 leper
 leprosy
-lesbian
 lesion
 lessen
 lesser
@@ -5862,7 +5819,6 @@ lyric
 lyrical
 macabre
 macaroni
-machete
 machine
 machinery
 machinist
@@ -5921,7 +5877,6 @@ malign
 malignant
 mallard
 malleable
-mallet
 maltreat
 mamma
 mammal
@@ -5978,7 +5933,6 @@ margin
 marginal
 maria
 marigold
-marijuana
 marina
 marinate
 marine
@@ -6012,7 +5966,6 @@ masculine
 masochist
 mason
 masonry
-massacre
 massage
 massive
 massively
@@ -6800,7 +6753,6 @@ organ
 organic
 organism
 organist
-orgasm
 orient
 oriental
 orientate
@@ -7942,7 +7894,6 @@ rapid
 rapider
 rapidity
 rapidly
-rapist
 rapport
 rapture
 rarely
@@ -8050,7 +8001,6 @@ rectal
 rectangle
 rectify
 rector
-rectum
 recur
 recurrent
 recursion
@@ -8496,9 +8446,6 @@ sacrilege
 sadden
 sadder
 saddle
-sadism
-sadist
-sadistic
 sadly
 safari
 safeguard
@@ -8561,7 +8508,6 @@ sarcastic
 sardine
 sassier
 sassy
-satanic
 satchel
 satellite
 satin
@@ -8755,7 +8701,6 @@ selfish
 seller
 semantic
 semblance
-semen
 semester
 semicolon
 semifinal
@@ -8824,11 +8769,6 @@ severer
 severity
 sewage
 sewer
-sexism
-sexist
-sexual
-sexuality
-sexually
 shabbier
 shabbily
 shabby
@@ -9082,9 +9022,7 @@ slander
 slang
 slant
 slapstick
-slash
 slate
-slaughter
 slave
 slavery
 slavish
@@ -9243,7 +9181,6 @@ sociology
 socket
 sodden
 sodium
-sodomy
 softball
 soften
 softer
@@ -9295,8 +9232,6 @@ sooty
 sophistry
 sophomore
 soprano
-sorcerer
-sorcery
 sordid
 sorely
 sorer
@@ -9374,7 +9309,6 @@ speller
 spelt
 spend
 spent
-sperm
 sphere
 spherical
 sphinx
@@ -9454,7 +9388,6 @@ sprout
 spruce
 sprucer
 sprung
-spunk
 spurn
 spurt
 sputter
@@ -9598,7 +9531,6 @@ stifle
 stigma
 stigmata
 still
-stillborn
 stiller
 stimulant
 stimulate
@@ -10753,9 +10685,6 @@ vacillate
 vacuum
 vagabond
 vagary
-vagina
-vaginae
-vaginal
 vagrant
 vague
 vaguely
@@ -10884,8 +10813,6 @@ violet
 violin
 viper
 viral
-virgin
-virginity
 virile
 virility
 virtual


### PR DESCRIPTION
I think we should have a general policy that the bundled word list will always be at least 10,000 words. We'll take any requests for removal of words up unto that limit, but after that only replacements will be made.