### PR TITLE
Fix pwgen-xkcd.pl when called with no arguments

### DIFF
--- a/lib/CtrlO/Crypt/XkcdPassword.pm
+++ b/lib/CtrlO/Crypt/XkcdPassword.pm
@@ -174,7 +174,7 @@ sub xkcd {
         croak "Invalid key [$key] received."
             unless ($key eq 'words' || $key eq 'digits');
 
-        if (defined $args{$key} && ($args{$key} !~ /^[1-9][0-9]?$/)) {
+        if (defined $args{$key} && ($args{$key} !~ /^[0-9]+$/)) {
             croak "Invalid value [$args{$key}] for key [$key].";
         }
     }

--- a/t/10-xkcd.t
+++ b/t/10-xkcd.t
@@ -47,6 +47,16 @@ subtest 'words=>3, digits=>3' => sub {
     );
 };
 
+subtest 'words=>4, digits=>0' => sub {
+    my $pw = $pwgen->xkcd( words => 4, digits => 0 );
+
+    like(
+        $pw,
+        qr/^(\p{Uppercase}\p{Lowercase}+){4}$/,
+        'looks like a XKCD pwd with 4 words and 0 digits'
+    );
+};
+
 subtest 'invalid params: key' => sub {
     foreach my $param (qw(wordx digitx)) {
         throws_ok { $pwgen->xkcd( $param => 3 ) }
@@ -57,12 +67,18 @@ subtest 'invalid params: key' => sub {
 
 subtest 'invalid params: value' => sub {
     foreach my $param (
-        [ words => 0],
+        [ words => 0.5],
         [ words => -1],
         [ words => 'a'],
-        [ digits => 0 ],
+        [ words => '123a' ],
+        [ words => 'a123' ],
+        [ words => "" ],
+        [ digits => 0.5 ],
         [ digits => -1 ],
         [ digits => 'a' ],
+        [ digits => '123a' ],
+        [ digits => 'a123' ],
+        [ digits => "" ],
     ) {
         throws_ok { $pwgen->xkcd( @$param ) }
             qr/^Invalid value/,


### PR DESCRIPTION
Running pwgen-xkcd.pl returns the following error:

``  Invalid value [0] for key [digits]. at pwgen-xkcd.pl line 27.``

This change fixes that and permits zero values for both the "digits" and "words" arguments to the xkcd() method.  This fix required changing the test suite's expectations.  I also added a few extra tests.