### PR TITLE
Avoid generating negative integers

### DIFF
--- a/lib/CtrlO/Crypt/XkcdPassword.pm
+++ b/lib/CtrlO/Crypt/XkcdPassword.pm
@@ -192,7 +192,7 @@ sub xkcd {
         push(
             @$words,
             sprintf(
-                '%0' . $d . 'd',
+                '%0' . $d . 'u',
                 with_entropy_source(
                     $self->entropy, sub { rand_int( 10**$d ) }
                 )


### PR DESCRIPTION
CPAN Testers reports show occasional test failures.  These seem to happen due to `xkcd()` generating passwords containing negative integers.  I expect this change will avoid that problem.