### PR TITLE
Extend `dist.ini` attributes to fix listdeps failures

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,7 @@
 name    = CtrlO-Crypt-XkcdPassword
+license = Perl_5
+author  = Thomas Klausner <domm@plix.at>
+copyright_holder = Thomas Klausner
 copyright_year   = 2018 - 2021
 
 [@Author::DOMM]


### PR DESCRIPTION
I found similar `Dist::Zilla` build problems to those found in
https://github.com/domm/App-TimeTracker/pull/52.  For instance, running

```
dist listdeps --author --missing
```

gave the warning

```
[DZ] no license data in config, no %Rights stash, couldn't make a good
guess at license from Pod; giving up.  Perhaps you need to set up a
global config file (dzil setup)? at inline delegation in Dist::Zilla for
logger->log_fatal (attribute declared in
```

IIRC, we found a change to `Dist::Zilla` which meant that the current
`dist.ini` now had insufficient attributes set in order for `dist
listdeps` to run without emiiting warnings.  I therefore extended the
`dist.ini` attributes to match those used in `App::TimeTracker`.  Adding
these attributes removed the warnings and allowed the dependencies to be
found and installed as usual.