### PR TITLE
Add META.yml to distribution

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,5 +2,6 @@ name    = CtrlO-Crypt-XkcdPassword
 copyright_year   = 2018 - 2021
 
 [@Author::DOMM]
+[MetaYAML]
 [Prereqs / TestRecommends]
 Bad::Words = 0.09


### PR DESCRIPTION
The presence of this file is considered to be part of the core kwalitee
metrics as mentioned on CPANTS.

@domm: I noticed that several of your dists are shown as missing the `META.yml` file on CPANTS. Perhaps the `MetaYAML` plugin should be added to your author bundle? If you want, I can submit a PR to your author bundle to add the plugin there.