### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/lib/CtrlO/Crypt/XkcdPassword.pm
+++ b/lib/CtrlO/Crypt/XkcdPassword.pm
@@ -1,6 +1,7 @@
 package CtrlO::Crypt::XkcdPassword;
 use strict;
 use warnings;
+use 5.010;
 
 # ABSTRACT: Yet another xkcd style password generator
 

--- a/lib/CtrlO/Crypt/XkcdPassword/Wordlist/en_gb.pm
+++ b/lib/CtrlO/Crypt/XkcdPassword/Wordlist/en_gb.pm
@@ -2,6 +2,7 @@ package CtrlO::Crypt::XkcdPassword::Wordlist::en_gb;
 use strict;
 use warnings;
 use utf8;
+use 5.010;
 
 use base 'WordList';
 


### PR DESCRIPTION
`Perl::MinimumVersion` showed that the minimum Perl version used within
this dist was 5.10.  It can be a good idea to specify this so that other
distributions and Perl tooling can be made aware of which minimum Perl
version to require before installing the dist.