### PR TITLE
Add initial GitHub actions config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,26 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  perl_tester:
+    runs-on: 'ubuntu-latest'
+    name: "perl v${{ matrix.perl-version }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - "5.30"
+          - "5.28"
+          - "5.26"
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cpanm --notest Dist::Zilla
+      - run: dzil authordeps --missing | cpanm
+      - run: dzil listdeps --author --missing | cpanm
+      - run: dzil test --author --release


### PR DESCRIPTION
... which allows the dist to be built and tested on GitHub infrastructure.  This avoids issues with Travis CI and a lack of available processing credits for OSS projects.

It turns out that Perls 5.24 and below can't test, which seems to be an issue with an upstream distribution.  The error message is:

```
fatal: Not a git repository (or any parent up to mount point /__w)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
Error: Process completed with exit code 128.
```

and I've seen similar issues with `Dist::Zilla` Git plugins which can have issues in CI/CD infrastructure such as Appveyor, Travis or GitHub Actions.  However, this *doesn't* mean that the current dist *can't* be used on Perls 5.24 and older; it just means that the tests won't necessarily be able to run.